### PR TITLE
Add emmet html support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1200,6 +1200,142 @@
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.1.4.tgz",
       "integrity": "sha512-WHn6ClDzGS3oACt4F/k0B9QwhQCeXXRguYE6UFe6OD6wLdESU8RoMs7Y1+FEr4Tj2VZd9bfb1aEhnB9KoVrLEA=="
     },
+    "@emmetio/abbreviation": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-0.7.0.tgz",
+      "integrity": "sha512-CjLWtUCyh2nRgG/TkBruPTNI03i+b2Bau9UP7g0zgWdeV6bBjNC8CxX106ZdMekK3I/RmTrWuzVV9b+7nwqKXA==",
+      "requires": {
+        "@emmetio/node": "^0.1.2",
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "@emmetio/css-abbreviation": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-0.4.0.tgz",
+      "integrity": "sha512-8b4+ZoBElpNMedO+gGCiEX/xGv8Do0NYUvsdVNv6O0fuP9octnxyzjb7HFGqDJ7hFzVORAfzOhpjyL8y2dw9AQ==",
+      "requires": {
+        "@emmetio/node": "^0.1.2",
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "@emmetio/css-snippets-resolver": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-snippets-resolver/-/css-snippets-resolver-0.4.0.tgz",
+      "integrity": "sha512-H0eOed2KljA/nQ64j3BKwAkAFliku5LAD58o4pvS3A9tZ2g3ctEpJ+61po78SZE1+Q+gRA3CGtC6rxtk7QlGPA=="
+    },
+    "@emmetio/field-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/field-parser/-/field-parser-0.3.1.tgz",
+      "integrity": "sha512-A26JuVvZRUBb/rNpaDdmBB2jaN3spx2JRLJQfkskz9CRbiSW9ZE/M7etKKMunV5UWUfSlygFaFUclT3y+UNDxw==",
+      "requires": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "@emmetio/html-snippets-resolver": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-snippets-resolver/-/html-snippets-resolver-0.1.4.tgz",
+      "integrity": "sha1-szrT+nj9eNZLlL+Iqftos62Ojn4=",
+      "requires": {
+        "@emmetio/abbreviation": "^0.6.0"
+      },
+      "dependencies": {
+        "@emmetio/abbreviation": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-0.6.6.tgz",
+          "integrity": "sha512-jsh1Hyc7iY+5tADcn6GlIF/kxEbglPW+JE/FcCb4NNYqDr2swXvEGWd+DN3porBA67VDfDZVAwThhvYTsHKrRw==",
+          "requires": {
+            "@emmetio/node": "^0.1.2",
+            "@emmetio/stream-reader": "^2.2.0",
+            "@emmetio/stream-reader-utils": "^0.1.0"
+          }
+        }
+      }
+    },
+    "@emmetio/html-transform": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-transform/-/html-transform-0.3.10.tgz",
+      "integrity": "sha512-GxKcFDCkHQAre4lBRr4hbyYfRhAtTqDrcnwDi2n97CX6bKhdfL9p7fZIobtNtjX+ZdCVs36x4vizpiChEYOArg==",
+      "requires": {
+        "@emmetio/implicit-tag": "^1.0.0"
+      }
+    },
+    "@emmetio/implicit-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/implicit-tag/-/implicit-tag-1.0.0.tgz",
+      "integrity": "sha1-+CbU4fxR2jlDTCMmtvbQ4rLntBk="
+    },
+    "@emmetio/lorem": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@emmetio/lorem/-/lorem-1.0.2.tgz",
+      "integrity": "sha1-jealcY85Fy6n0iUypbDTu9EAg9w=",
+      "requires": {
+        "@emmetio/implicit-tag": "^1.0.0"
+      }
+    },
+    "@emmetio/markup-formatters": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/markup-formatters/-/markup-formatters-0.4.1.tgz",
+      "integrity": "sha512-RR+QPozAAL7pnFL5Nl3g5qXxUF2qw54oGl0njmBTZYYwf96LDJ2p6DfRhy8uCenRjMMgUijjQ31wtmDR4cobDA==",
+      "requires": {
+        "@emmetio/field-parser": "^0.3.0",
+        "@emmetio/output-renderer": "^0.1.2"
+      }
+    },
+    "@emmetio/node": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@emmetio/node/-/node-0.1.2.tgz",
+      "integrity": "sha1-QjHVOMRUgaUYNfwquj9dn8EpY0w="
+    },
+    "@emmetio/output-profile": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@emmetio/output-profile/-/output-profile-0.1.6.tgz",
+      "integrity": "sha512-7bIwR3YHmTEnyy76X4l9e5+wXE+lah2E1AIoeDyKFIfVujztXNqcv+BmPcV4LRl1+V6Qir8hIex+F2nz7PTPCg=="
+    },
+    "@emmetio/output-renderer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@emmetio/output-renderer/-/output-renderer-0.1.2.tgz",
+      "integrity": "sha1-Ds4RrM6SmFB4aK7SGrUlPh6wgvg=",
+      "requires": {
+        "@emmetio/field-parser": "^0.3.0"
+      }
+    },
+    "@emmetio/snippets": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@emmetio/snippets/-/snippets-0.2.12.tgz",
+      "integrity": "sha512-xgjkyLZ4Ez8kN2qGNY59MadoIlStIohn80/FUSk+/DyNp/0SVpAe+/uQ5qJ4Mo4DDzfnkEkfCBMO/yq4SKoB0w=="
+    },
+    "@emmetio/snippets-registry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/snippets-registry/-/snippets-registry-0.3.1.tgz",
+      "integrity": "sha1-7A6KEi/paDZZzmmiI5b0E2uUDSA="
+    },
+    "@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha1-Rs/+oRmgoAMxKiHC2bVijLX81EI="
+    },
+    "@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha1-JEywLHfsLnT3ipvTGCGKvJxQCmE="
+    },
+    "@emmetio/stylesheet-formatters": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/stylesheet-formatters/-/stylesheet-formatters-0.2.1.tgz",
+      "integrity": "sha512-1XHNVx6S3ra7dnv12CNT6Gq15VyT2Fkrhgp2yCj4g2jJJflVHU6t++VfjoK6w36hGYu0AqZL9TCa/8hLj2YjQw==",
+      "requires": {
+        "@emmetio/field-parser": "^0.3.0",
+        "@emmetio/output-renderer": "^0.1.1"
+      }
+    },
+    "@emmetio/variable-resolver": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/variable-resolver/-/variable-resolver-0.2.1.tgz",
+      "integrity": "sha1-zhG1FYRmmjQJhmkM8OwmnkTGP7o="
+    },
     "@fullhuman/postcss-purgecss": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.3.0.tgz",
@@ -4286,6 +4422,25 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         }
+      }
+    },
+    "emmet-monaco-es": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/emmet-monaco-es/-/emmet-monaco-es-4.4.2.tgz",
+      "integrity": "sha512-34TxxTO3/MG8Ke4+QXZfqcxLthKvmnwyxkCPUwjhDmcssKxFHDCmOCJHScnXaWkmn0ywQD9A0rSt1obYa8grYQ==",
+      "requires": {
+        "@emmetio/abbreviation": "^0.7.0",
+        "@emmetio/css-abbreviation": "^0.4.0",
+        "@emmetio/css-snippets-resolver": "^0.4.0",
+        "@emmetio/html-snippets-resolver": "^0.1.4",
+        "@emmetio/html-transform": "^0.3.10",
+        "@emmetio/lorem": "^1.0.2",
+        "@emmetio/markup-formatters": "^0.4.1",
+        "@emmetio/output-profile": "^0.1.6",
+        "@emmetio/snippets": "^0.2.12",
+        "@emmetio/snippets-registry": "^0.3.1",
+        "@emmetio/stylesheet-formatters": "^0.2.1",
+        "@emmetio/variable-resolver": "^0.2.1"
       }
     },
     "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "debounce": "^1.2.0",
     "dlv": "^1.1.3",
     "dset": "^2.0.1",
+    "emmet-monaco-es": "^4.4.2",
     "eslint": "6.x",
     "eslint-config-react-app": "^5.2.1",
     "eslint-plugin-flowtype": "4.x",

--- a/src/monaco/index.js
+++ b/src/monaco/index.js
@@ -1,4 +1,5 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import { emmetHTML, emmetCSS } from 'emmet-monaco-es'
 import PrettierWorker from 'worker-loader?publicPath=/_next/&filename=static/chunks/[name].[hash].js&chunkFilename=static/chunks/[id].[contenthash].worker.js!../workers/prettier.worker.js'
 import { createWorkerQueue } from '../utils/workers'
 import { setupHtmlMode } from './html'
@@ -76,6 +77,9 @@ export function createMonacoEditor({
     theme: getTheme() === 'dark' ? 'tw-dark' : 'vs',
   })
   disposables.push(editor)
+
+  const emmet = emmetHTML(window.moncaco)
+  disposables.push(emmet)
 
   setupKeybindings(editor)
 


### PR DESCRIPTION
This pull request adds emmet HTML support to the editor you can see emmet in action here: https://www.loom.com/share/ac5769018a3c48e09523657e4c243e5d

Emmet support is added using the plugin: https://www.npmjs.com/package/emmet-monaco-es

Please let me know if you would like any tests written for this or need any more info!

Edit: this does seem to have collisions with the intellesense stuff which is already enabled, might be best to chat this over and see if we can make this smoother