### PR TITLE
Add "Format" button to allow pretty formatting of editor

### DIFF
--- a/src/components/Format.js
+++ b/src/components/Format.js
@@ -1,0 +1,17 @@
+export function Format({ editorRef }) {
+  return (
+    <div className="hidden sm:flex items-center space-x-4 min-w-0">
+      <button
+        type="button"
+        className="relative flex-none rounded-md border border-gray-200 text-sm font-medium leading-5 py-1.5 px-4 focus:border-turquoise-400 focus:outline-none focus:shadow-outline dark:bg-gray-800 dark:border-transparent dark:focus:bg-gray-700 dark:focus:border-turquoise-500 hover:bg-gray-50 dark:hover:bg-gray-700"
+        onClick={() => {
+          editorRef.current.editor
+            .getAction('editor.action.formatDocument')
+            .run()
+        }}
+      >
+        Format
+      </button>
+    </div>
+  )
+}

--- a/src/pages/[[...slug]].js
+++ b/src/pages/[[...slug]].js
@@ -14,6 +14,7 @@ import Error from 'next/error'
 import { ErrorOverlay } from '../components/ErrorOverlay'
 import Router from 'next/router'
 import { Header } from '../components/Header'
+import { Format } from '../components/Format'
 import { Share } from '../components/Share'
 import { TabBar } from '../components/TabBar'
 import { sizeToObject } from '../utils/size'
@@ -293,6 +294,7 @@ function Pen({
           activeTab={activeTab}
           tailwindVersion={tailwindVersion}
         />
+        <Format editorRef={editorRef} />
       </Header>
       <main className="flex-auto relative border-t border-gray-200 dark:border-gray-800">
         {initialContent && typeof size.current !== 'undefined' ? (


### PR DESCRIPTION
Adding the ability to format the editor by adding a "Format" button.

- I was not sure where to place the button, please share your feedback as to where you think it should appear. 
- I couldn't find any documentation or tests to update for this feature. Let me know if I am missing anything to add to the PR.

![Screenshot 2020-11-19 at 5 55 52 PM](https://user-images.githubusercontent.com/4616064/99650845-ddd03880-2a90-11eb-8fd0-e3a3eb9ee3fb.png)

