### PR TITLE
Update Default Content Docs Link To Link to Documentation Page

### DIFF
--- a/src/preval/defaultContent.js
+++ b/src/preval/defaultContent.js
@@ -65,7 +65,7 @@ module.exports = () => {
           <div class="pt-6 text-base leading-6 font-bold sm:text-lg sm:leading-7">
             <p>Want to dig deeper into Tailwind?</p>
             <p>
-              <a href="https://tailwindcss.com" class="text-cyan-600 hover:text-cyan-700"> Read the docs &rarr; </a>
+              <a href="https://tailwindcss.com/docs" class="text-cyan-600 hover:text-cyan-700"> Read the docs &rarr; </a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
Updates the "Read the docs" link URL from directing to the homepage of  
tailwindcss.com to the documentation route within the tailwindcss.com  
site.

The link directing to the homepage, rather than the documentation page  
feels like a misalignment of what the link describes, which lead to the  
decision to change the URL of the link to direct to the documentation  
page.

**Screenshot**

![Screen Shot 2020-11-27 at 13.48.48.png](https://cdn-std.droplr.net/files/acc_725208/NHukH2)