### PR TITLE
Fix script parsing DX

### DIFF
--- a/src/utils/validateJavaScript.js
+++ b/src/utils/validateJavaScript.js
@@ -1,25 +1,16 @@
 export function validateJavaScript(script) {
   return new Promise((resolve) => {
-    const stringToEval = `throw new Error('Parsing successful!');function _hmm(){\n${script}\n}`
-    const $script = document.createElement('script')
-    $script.innerHTML = stringToEval
-
-    window.addEventListener('error', function onError(errorEvent) {
-      errorEvent.preventDefault()
-      window.removeEventListener('error', onError)
-      $script.parentNode.removeChild($script)
-      if (errorEvent.message.indexOf('Parsing successful') !== -1) {
-        resolve({ isValid: true })
-        return
-      }
+    try {
+      new Function(script)
+      resolve({ isValid: true })
+    } catch (err) {
       resolve({
         isValid: false,
         error: {
-          line: errorEvent.lineno - 1,
-          message: errorEvent.error.toString(),
+          line: err.line - 1,
+          message: err.toString(),
         },
       })
-    })
-    document.body.appendChild($script)
+    }
   })
 }


### PR DESCRIPTION
Now when starting the server you won't get an error overlay that parsing was successful. The correct API for this is `new Function(code)`. Note that when using a content-security-policy you'll need to add unsafe-eval.

"just close the modal and pretend it didn't happen" - @adamwathan 

I took it to heart and have closed the modal permanently. For everyone. 😈 

cc @RobinMalfait @adamwathan 