### PR TITLE
Fix "generated CSS" panel when starting in preview mode

### DIFF
--- a/src/components/EditorDesktop.js
+++ b/src/components/EditorDesktop.js
@@ -5,6 +5,7 @@ import { onDidChangeTheme, getTheme } from '../utils/theme'
 import SplitPane from 'react-split-pane'
 import clsx from 'clsx'
 import Alert from '@reach/alert'
+import { extractCss } from '../utils/extractCss'
 
 export default function Editor({
   initialContent = {},
@@ -16,6 +17,7 @@ export default function Editor({
   tailwindVersion,
   onFilterCssOutput,
   cssOutputFilter,
+  initialCssOutput = '',
 }) {
   const editorContainerRef = useRef()
   const editorRef = useRef()
@@ -60,6 +62,7 @@ export default function Editor({
         fixedOverflowWidgets: true,
         readOnly: true,
         language: 'tailwindcss',
+        value: extractCss(initialCssOutput, cssOutputFilter),
         renderLineHighlight: false,
         padding: { top: 49 },
       }

--- a/src/utils/extractCss.js
+++ b/src/utils/extractCss.js
@@ -1,0 +1,26 @@
+export function extractCss(rawCss, filter) {
+  let result = rawCss
+  let re =
+    /\s*\/\*\s*__play_start_(base|components|utilities)__\s*\*\/(.*?)\/\*\s*__play_end_\1__\s*\*\//gs
+  if (filter.length === 0) {
+    result = result.replace(re, (_match, _layerName, layerCss) => layerCss)
+  } else {
+    let chunks = []
+    let match
+    while ((match = re.exec(result)) !== null) {
+      let [, layerName, layerCss] = match
+      if (filter.includes(layerName)) {
+        let trimmedCss = layerCss.trim()
+        if (trimmedCss) {
+          chunks.push(trimmedCss)
+        }
+      }
+    }
+    result = chunks.join('\n\n')
+  }
+  result = result.trim().replace(/\n{3,}/g, '\n\n')
+  if (result.trim() !== '') {
+    result = result + '\n'
+  }
+  return result
+}


### PR DESCRIPTION
This PR fixes a couple of issues that arise when the app starts in preview mode, e.g. https://play.tailwindcss.com/uj1vGACRJA?layout=preview

The first fix is to ensure that there's always a `<div>` where the editor should be, as `<SplitPane>` cannot have undefined children.

The second fix is to ensure that an initial value is passed to the CSS output editor so that if it initialises late the value is populated correctly.