### PR TITLE
Add type annotation in Tailwind config

### DIFF
--- a/src/utils/getDefaultContent.js
+++ b/src/utils/getDefaultContent.js
@@ -66,7 +66,8 @@ export async function getDefaultContent() {
 </div>
 `
   const css = '@tailwind base;\n@tailwind components;\n@tailwind utilities;\n'
-  const config = `module.exports = {
+  const config = `/** @type {import('tailwindcss').Config} */
+module.exports = {
   theme: {
     extend: {
       // ...


### PR DESCRIPTION
This pull request will add a type annotation in the Tailwind config in src/utils/getDefaultContent.js.

Even though intellisense for the Tailwind config is available by default in the playground editor, adding this type annotation will be useful if someone wants to copy the changes they made in the config in the playground, paste it in their editor, while still having code completion. Also, since running `tailwindcss init` adds the type annotation by default, I thought it was a good idea to add it in here.

I hope this is fine.